### PR TITLE
PRM-3526 Release 2.9.0

### DIFF
--- a/.coverage/clover.xml
+++ b/.coverage/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1770978294">
-  <project timestamp="1770978294">
+<coverage generated="1771548405">
+  <project timestamp="1771548405">
     <file name="/home/runner/work/svc-sdk-php/svc-sdk-php/src/Auth/AuthToken.php">
       <class name="CVLB\Svc\Api\Auth\AuthToken" namespace="global">
         <metrics complexity="5" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="6" coveredstatements="6" elements="11" coveredelements="11"/>

--- a/.coverage/clover.xml
+++ b/.coverage/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1722458433">
-  <project timestamp="1722458433">
+<coverage generated="1771549893">
+  <project timestamp="1771549893">
     <file name="/home/runner/work/svc-sdk-php/svc-sdk-php/src/Auth/AuthToken.php">
       <class name="CVLB\Svc\Api\Auth\AuthToken" namespace="global">
         <metrics complexity="5" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="6" coveredstatements="6" elements="11" coveredelements="11"/>

--- a/.coverage/clover.xml
+++ b/.coverage/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1712610995">
-  <project timestamp="1712610995">
+<coverage generated="1770978294">
+  <project timestamp="1770978294">
     <file name="/home/runner/work/svc-sdk-php/svc-sdk-php/src/Auth/AuthToken.php">
       <class name="CVLB\Svc\Api\Auth\AuthToken" namespace="global">
         <metrics complexity="5" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="6" coveredstatements="6" elements="11" coveredelements="11"/>

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Fixed
 
+## [2.9.0] - 2026-02-13
+### Changed
+- Allow laminas/laminas-diactoros ^3.0 for PHP 8.4/8.5 compatibility
+- Drop PHP 7.4 support (EOL)
+- Remove unused Laminas\Diactoros\StreamFactory import from SlackService
+
 ## [2.8.0] - 2024-04-08
 ### Changed
 - Updated package laminas/laminas-diactoros to 2.26.0

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "license": "proprietary",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.1",
-        "laminas/laminas-diactoros": "^2.18.1",
+        "php": "^8.1",
+        "laminas/laminas-diactoros": "^2.18.1 || ^3.0",
         "psr/http-factory": "^1.0",
         "psr/http-client": "^1.0",
         "php-http/client-common": "^2.6",

--- a/src/Services/Notify/Protocols/Chat/SlackService.php
+++ b/src/Services/Notify/Protocols/Chat/SlackService.php
@@ -3,7 +3,7 @@
 namespace CVLB\Svc\Api\Services\Notify\Protocols\Chat;
 
 use CVLB\Svc\Api\HttpClient\Message\ResponseMediator;
-use Laminas\Diactoros\StreamFactory;
+
 use Yaf\Request\Http;
 
 final class SlackService extends AbstractChatService


### PR DESCRIPTION
## Summary

Release 2.9.0 — merge develop into main.

## Changes (from PR #36)

- Widen `laminas/laminas-diactoros` constraint from `^2.18.1` to `^2.18.1 || ^3.0`
- Drop PHP 7.4 support (EOL)
- Remove unused `Laminas\Diactoros\StreamFactory` import from SlackService

## Context

This unblocks PHP 8.5 compatibility for Admin Portal. After merge, tag as v2.9.0.